### PR TITLE
Minor fix to work in RecycleView

### DIFF
--- a/library/src/main/java/net/mediavrog/irr/IrrLayout.java
+++ b/library/src/main/java/net/mediavrog/irr/IrrLayout.java
@@ -368,17 +368,17 @@ public class IrrLayout extends FrameLayout {
         switch (step) {
             case NUDGE:
                 mNudgeView.setVisibility(VISIBLE);
-                mRateView.setVisibility(GONE);
-                mFeedbackView.setVisibility(GONE);
+                mRateView.setVisibility(INVISIBLE);
+                mFeedbackView.setVisibility(INVISIBLE);
                 break;
             case RATE:
-                mNudgeView.setVisibility(GONE);
+                mNudgeView.setVisibility(INVISIBLE);
                 mRateView.setVisibility(VISIBLE);
-                mFeedbackView.setVisibility(GONE);
+                mFeedbackView.setVisibility(INVISIBLE);
                 break;
             case FEEDBACK:
-                mNudgeView.setVisibility(GONE);
-                mRateView.setVisibility(GONE);
+                mNudgeView.setVisibility(INVISIBLE);
+                mRateView.setVisibility(INVISIBLE);
                 mFeedbackView.setVisibility(VISIBLE);
                 break;
         }


### PR DESCRIPTION
This change fixes the problem with recounting the card height in RecycleView after view child views become completely invisible. Probably needs better solution, however it works fine at the moment.